### PR TITLE
Add support for automatic building, also creating arm32 and arm64 versions

### DIFF
--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -20,9 +20,9 @@ jobs:
             run: |
                 image_name="${{secrets.DOCKER_USERNAME}}/apt-cacher-ng"
                 date=$(date '+%Y-%m-%d')
-                apt-cacher-ng-version="apt-cacher-ng-3.6.4"
-                full="${apt-cacher-ng-version}-${date}"
-                tags="${image_name}:${apt-cacher-ng-version},${image_name}:${full},${image_name}:latest"
+                apt_cacher_ng_version="apt-cacher-ng-3.6.4"
+                full="${apt_cacher_ng_version}-${date}"
+                tags="${image_name}:${apt_cacher_ng_version},${image_name}:${full},${image_name}:latest"
                 echo "RELEASE_TAGS=${tags}" >> $GITHUB_ENV
         -
             name: Set up QEMU

--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -1,0 +1,49 @@
+name: Publish multi-arch Docker images
+
+on:
+    push:
+        branches:
+            - main
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+                
+        steps:
+        -
+            name: Checkout
+            uses: actions/checkout@v2
+        -
+            name: Set Release Tag
+            run: |
+                image_name="${{secrets.DOCKER_USERNAME}}/apt-cacher-ng"
+                date=$(date '+%Y-%m-%d')
+                apt-cacher-ng-version="apt-cacher-ng-3.6.4"
+                full="${apt-cacher-ng-version}-${date}"
+                tags="${image_name}:${apt-cacher-ng-version},${image_name}:${full},${image_name}:latest"
+                echo "RELEASE_TAGS=${tags}" >> $GITHUB_ENV
+        -
+            name: Set up QEMU
+            uses: docker/setup-qemu-action@v1
+            with:
+                platforms: all
+        -
+            name: Set up Docker Buildx
+            id: buildx
+            uses: docker/setup-buildx-action@v1
+        -
+            name: Login to DockerHub
+            uses: docker/login-action@v1
+            with:
+                username: ${{ secrets.DOCKER_USERNAME }}
+                password: ${{ secrets.DOCKER_PASSWORD }}
+        -
+            name: Build and push
+            uses: docker/build-push-action@v2
+            with:
+                context: .
+                platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
+                push: true
+                tags: ${{ env.RELEASE_TAGS }}

--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -3,7 +3,7 @@ name: Publish multi-arch Docker images
 on:
     push:
         branches:
-            - main
+            - master
 
 jobs:
     release:

--- a/README.md
+++ b/README.md
@@ -46,3 +46,10 @@ You can also update the /etc/apt-cacher-ng/acng.conf and add one or more `PassTh
 PassThroughPattern: get\.docker\.com
 PassThroughPattern: download\.virtualbox\.org
 ```
+
+## Available Archs on Docker Hub
+
+- linux/amd64
+- linux/arm/v7
+- linux/arm64/v8
+


### PR DESCRIPTION
Hello, I cloned your repo because I wanted to create arm versions of your image.
Also, I wanted to have multiple versions of the image. For example, the workflow can be extended so (for example), when a new debian stable version comes out, you might still want to regularly build an image with bullseye and another build with the current stable, at least for a while.
The workflow requires as you can imagine these two secrets:

DOCKER_USERNAME
DOCKER_PASSWORD

You can have a look at the resulting builds here:
https://hub.docker.com/repository/docker/giof71/apt-cacher-ng/tags?page=1&ordering=last_updated

EDIT: link to builds was missing, reviewed description