### PR TITLE
Updated to debian trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # rebased/repackaged base image that only updates existing packages
-FROM mbentley/debian:bullseye
+FROM mbentley/debian:trixie
 LABEL maintainer="Matt Bentley <mbentley@mbentley.net>"
 
 RUN apt-get update &&\


### PR DESCRIPTION
Did some testing across 8 containers doing updates and downloads are the same time and it worked fine; hopefully the [reasons I switched back to bullseye](https://github.com/mbentley/docker-apt-cacher-ng/issues/7) don't come back up.